### PR TITLE
fix: LNB에서 사용하는 아이콘 색 변경되지 않는 이슈 해결

### DIFF
--- a/src/assets/svg/RightUpArrow.svg
+++ b/src/assets/svg/RightUpArrow.svg
@@ -1,3 +1,3 @@
 <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M10.9796 9.47287L11 5.33832C11.0009 5.16364 10.8604 5.02133 10.6864 5.02048L6.5225 5M10.8971 5.10293L4 12" stroke="#4C5057" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M10.9796 9.47287L11 5.33832C11.0009 5.16364 10.8604 5.02133 10.6864 5.02048L6.5225 5M10.8971 5.10293L4 12" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
 </svg>

--- a/src/components/atoms/Icon.tsx
+++ b/src/components/atoms/Icon.tsx
@@ -54,6 +54,7 @@ export function Icon({ name, color, size = 'md', customSize, fill = false, class
     <div className={`inline-flex ${customSize ? '' : sizeClass} ${colorClass} ${className}`}>
       <IconComponent
         fill={fill ? 'currentColor' : 'none'}
+        stroke={!fill ? 'currentColor' : 'none'}
         width={customSize?.width}
         height={customSize?.height}
         color={colorClass}

--- a/src/components/molecules/navigation/NavigationBarItem.tsx
+++ b/src/components/molecules/navigation/NavigationBarItem.tsx
@@ -53,6 +53,7 @@ const SubNavigationItem = ({ title, link, external }: { title: string; link?: st
     {external && (
       <Icon
         name="rightUpArrow"
+        color="gray-400"
         customSize={{ width: '16px', height: '16px' }}
         className="group-hover:text-primary-800 ml-1"
       />


### PR DESCRIPTION
<img width="157" alt="image" src="https://github.com/user-attachments/assets/998914ee-265d-4168-9bdb-830b6dd31409" />

- Icon 컴포넌트에서 stroke prop을 통해 아이콘 색을 설정할 수 있도록 처리했습니다.
- RightUpArrow.svg 파일에서 기본적으로 stroke 색이 정해져 있어서 변경이 되지 않는 것을 발견해 stroke 속성 삭제했습니다.