### PR TITLE
fix: input, select, textarea 태그 기본 스타일 지정

### DIFF
--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -1,3 +1,5 @@
+@import 'tailwindcss';
+
 @layer base {
   body {
     font-family:
@@ -43,5 +45,43 @@
   /* Safari hidden */
   select option[disabled] {
     display: none;
+  }
+
+  [multiple],
+  [type='date'],
+  [type='datetime-local'],
+  [type='email'],
+  [type='month'],
+  [type='number'],
+  [type='password'],
+  [type='search'],
+  [type='tel'],
+  [type='text'],
+  [type='time'],
+  [type='url'],
+  [type='week'],
+  input:where(:not([type])),
+  select,
+  textarea {
+    --tw-shadow: 0 0 #0000;
+    -webkit-appearance: none;
+    appearance: none;
+    background-color: #fff;
+    border-color: var(--gray-200);
+    border-radius: 0;
+    border-width: 1px;
+    font-size: 1rem;
+    line-height: 1.5rem;
+    padding: 0.5rem 0.75rem;
+  }
+
+  select {
+    background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 20 20'%3E%3Cpath stroke='%236b7280' stroke-linecap='round' stroke-linejoin='round' stroke-width='1.5' d='m6 8 4 4 4-4'/%3E%3C/svg%3E");
+    background-position: right 0.5rem center;
+    background-repeat: no-repeat;
+    background-size: 1.5em 1.5em;
+    padding-right: 2.5rem;
+    -webkit-print-color-adjust: exact;
+    print-color-adjust: exact;
   }
 }


### PR DESCRIPTION
Tailwind CSS를 V4로 업그레이드하면서 기존 태그들의 스타일이 깨지게 되었습니다.
기존에는 Tailwind에서 내부적으로 태그들에 대한 기본 스타일이 있었다가, 버전이 올라가며 사라지게 되었는지 특정 태그들에 대한 기본 스타일이 사라지게 되어 base 레이어에 추가하게 되었습니다.