### PR TITLE
feat: Checkbox 컴포넌트 생성

### DIFF
--- a/src/components/atoms/Checkbox.tsx
+++ b/src/components/atoms/Checkbox.tsx
@@ -1,0 +1,40 @@
+import { cn } from '@/utils/commonUtil'
+
+export interface CheckboxProps extends Omit<React.InputHTMLAttributes<HTMLInputElement>, 'size'> {
+  checked?: boolean
+  disabled?: boolean
+  className?: string
+  size?: 'sm' | 'md' | 'lg'
+}
+
+export function Checkbox({ className, disabled, id, checked = false, size = 'sm', ...props }: CheckboxProps) {
+  const sizeClasses = {
+    sm: 'h-4 w-4',
+    md: 'h-5 w-5',
+    lg: 'h-6 w-6',
+  }
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault()
+      e.currentTarget.click()
+    }
+  }
+
+  return (
+    <input
+      type="checkbox"
+      id={id}
+      className={cn(
+        'text-primary-800 checked:bg-primary-800 focus:ring-primary-800 rounded-sm border border-gray-300 bg-white hover:cursor-pointer',
+        sizeClasses[size],
+        disabled && 'disabled:cursor-not-allowed disabled:bg-gray-200',
+        className,
+      )}
+      checked={checked}
+      disabled={disabled}
+      onKeyDown={handleKeyDown}
+      {...props}
+    />
+  )
+}

--- a/src/components/atoms/Checkbox.tsx
+++ b/src/components/atoms/Checkbox.tsx
@@ -5,13 +5,19 @@ export interface CheckboxProps extends Omit<React.InputHTMLAttributes<HTMLInputE
   disabled?: boolean
   className?: string
   size?: 'sm' | 'md' | 'lg'
+  color?: 'primary' | 'secondary'
 }
 
-export function Checkbox({ className, disabled, id, checked = false, size = 'sm', ...props }: CheckboxProps) {
+export function Checkbox({ className, disabled, checked, size = 'sm', color = 'primary', ...props }: CheckboxProps) {
   const sizeClasses = {
     sm: 'h-4 w-4',
     md: 'h-5 w-5',
     lg: 'h-6 w-6',
+  }
+
+  const colorClasses = {
+    primary: 'checked:bg-primary-800',
+    secondary: 'checked:bg-secondary-800',
   }
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
@@ -24,16 +30,17 @@ export function Checkbox({ className, disabled, id, checked = false, size = 'sm'
   return (
     <input
       type="checkbox"
-      id={id}
       className={cn(
-        'text-primary-800 checked:bg-primary-800 focus:ring-primary-800 rounded-sm border border-gray-300 bg-white hover:cursor-pointer',
+        'cursor-pointer rounded-sm bg-white not-checked:border not-checked:border-gray-300 focus:ring-0 focus:ring-offset-0',
         sizeClasses[size],
+        colorClasses[color],
         disabled && 'disabled:cursor-not-allowed disabled:bg-gray-200',
         className,
       )}
       checked={checked}
       disabled={disabled}
       onKeyDown={handleKeyDown}
+      tabIndex={0}
       {...props}
     />
   )

--- a/src/index.css
+++ b/src/index.css
@@ -1,6 +1,7 @@
 @import url('https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/static/pretendard.min.css');
 
 @import 'tailwindcss';
+@plugin '@tailwindcss/forms';
 
 @import './styles/base.css';
 @import './styles/components.css';

--- a/src/stories/atoms/Checkbox.stories.tsx
+++ b/src/stories/atoms/Checkbox.stories.tsx
@@ -1,0 +1,37 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { Checkbox } from '@/atoms/Checkbox'
+import { useState } from 'react'
+
+const meta: Meta<typeof Checkbox> = {
+  title: 'Atoms/Checkbox',
+  component: Checkbox,
+  parameters: {
+    layout: 'centered',
+  },
+}
+
+export default meta
+type Story = StoryObj<typeof Checkbox>
+
+export const DefaultCheckbox: Story = {
+  args: {
+    disabled: false,
+  },
+}
+
+export const ControlledCheckbox: Story = {
+  render: () => {
+    const [isChecked, setIsChecked] = useState(false)
+
+    const handleChange = () => {
+      setIsChecked(!isChecked)
+    }
+
+    return (
+      <div className="flex gap-2">
+        <Checkbox checked={isChecked} onChange={handleChange} id="controlled-checkbox" />
+        <span className="text-sm text-gray-600">체크박스 상태: {isChecked ? '체크됨' : '체크되지 않음'}</span>
+      </div>
+    )
+  },
+}

--- a/src/stories/atoms/Checkbox.stories.tsx
+++ b/src/stories/atoms/Checkbox.stories.tsx
@@ -1,6 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react'
 import { Checkbox } from '@/atoms/Checkbox'
-import { useState } from 'react'
 
 const meta: Meta<typeof Checkbox> = {
   title: 'Atoms/Checkbox',
@@ -16,22 +15,5 @@ type Story = StoryObj<typeof Checkbox>
 export const DefaultCheckbox: Story = {
   args: {
     disabled: false,
-  },
-}
-
-export const ControlledCheckbox: Story = {
-  render: () => {
-    const [isChecked, setIsChecked] = useState(false)
-
-    const handleChange = () => {
-      setIsChecked(!isChecked)
-    }
-
-    return (
-      <div className="flex gap-2">
-        <Checkbox checked={isChecked} onChange={handleChange} id="controlled-checkbox" />
-        <span className="text-sm text-gray-600">체크박스 상태: {isChecked ? '체크됨' : '체크되지 않음'}</span>
-      </div>
-    )
   },
 }


### PR DESCRIPTION
- 기존 레포에서 설치해 사용하고 있던 tailwindcss/forms 플러그인이 적용되어 있지 않던 것을 발견해 적용했습니다.
   이로 인해  checkbox에 커스텀 스타일이 적용되지 않던 문제를 해결했습니다.

- 아토믹 패턴을 적용한 Atom 레벨인 Checkbox 컴포넌트를 생성했습니다.
   - 사이즈는 sm, md, lg를 사용하며 각각 16px, 20px, 24px입니다. ([디자인시스템 피그마](https://www.figma.com/design/pIYjkzqLRX5n3LqlVSokts/-%EB%94%94%EC%9E%90%EC%9D%B8-%EB%94%94%EC%9E%90%EC%9D%B8%EC%8B%9C%EC%8A%A4%ED%85%9C?node-id=589-1000&t=XXhpdf2sH2DRcMTa-0))
   - color를 primary와 secondary를 받아서 적용하도록 했습니다.
     - secondary는 아직 지정되지 않은 색이나, 곧 생길 것이라 판단해 미리 추가해두었습니다. ([LG_U+ 작업규칙 피그마](https://www.figma.com/design/WMUt4FW1rmthxispeWm1YT/-%EB%94%94%EC%9E%90%EC%9D%B8-%EC%8A%88%ED%8D%BC%EC%8A%A4%EC%BF%A8?node-id=6997-894&t=JMcgtYw186NemSmj-0))