### PR TITLE
fix: IB 체크리스트 - 단어수 isValid 처리 안 되는 이슈 해결

### DIFF
--- a/src/legacy/components/ib/ee/IbEeEssay.tsx
+++ b/src/legacy/components/ib/ee/IbEeEssay.tsx
@@ -146,6 +146,11 @@ export function IbEeEssay({
     mode: 'onChange',
   })
 
+  const handleCharCountChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value.replace(/[^0-9]/g, '')
+    e.target.value = value
+  }
+
   const onSubmit = async (data: RequestEssayDto) => {
     const documentFiles = [...documentObjectMap.values()]
       .filter((value) => !value.isDelete && value.document instanceof File)
@@ -191,9 +196,10 @@ export function IbEeEssay({
             <Input.Basic
               size={32}
               placeholder="예) 3600"
-              type="number"
-              value={essayData?.charCount}
+              type="text"
+              inputMode="numeric"
               className="w-[200px]"
+              onInput={handleCharCountChange}
               {...register('charCount', { valueAsNumber: true, required: true, validate: (value) => !!value })}
             />
           </div>
@@ -243,9 +249,10 @@ export function IbEeEssay({
             <Input.Basic
               size={32}
               placeholder="예) 3600"
-              type="number"
+              type="text"
+              inputMode="numeric"
               className="w-[200px]"
-              value={essayData?.charCount}
+              onInput={handleCharCountChange}
               {...register('charCount', { valueAsNumber: true, required: true, validate: (value) => !!value })}
             />
           </div>

--- a/src/legacy/components/ib/tok/IbEssay.tsx
+++ b/src/legacy/components/ib/tok/IbEssay.tsx
@@ -109,6 +109,11 @@ export function IbEssay({
     mode: 'onChange',
   })
 
+  const handleCharCountChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value.replace(/[^0-9]/g, '')
+    e.target.value = value
+  }
+
   const onSubmit = async (data: RequestEssayDto) => {
     if (isCreateEssay || isUpdateEssay) {
       return
@@ -147,10 +152,16 @@ export function IbEssay({
             <Input.Basic
               size={32}
               placeholder="예) 3600"
-              type="number"
-              value={essayData?.charCount}
+              type="text"
+              inputMode="numeric"
               className="w-[200px]"
-              {...register('charCount', { valueAsNumber: true, required: true, validate: (value) => !!value })}
+              value={essayData?.charCount}
+              onInput={handleCharCountChange}
+              {...register('charCount', {
+                valueAsNumber: true,
+                required: true,
+                validate: (value) => !!value,
+              })}
             />
           </div>
         </section>
@@ -180,10 +191,15 @@ export function IbEssay({
             <Input.Basic
               size={32}
               placeholder="예) 3600"
-              type="number"
+              type="text"
+              inputMode="numeric"
               className="w-[200px]"
-              value={essayData?.charCount}
-              {...register('charCount', { valueAsNumber: true, required: true, validate: (value) => !!value })}
+              onInput={handleCharCountChange}
+              {...register('charCount', {
+                valueAsNumber: true,
+                required: true,
+                validate: (value) => !!value,
+              })}
             />
           </div>
         </section>


### PR DESCRIPTION
- input 타입이 number인 경우 react-hook-form의 isValid가 정상적으로 동작하지 않는 것을 발견해 타입을 text로 설정하고 텍스트 입력 시 제거하도록 처리했습니다.
- 기존 슈퍼스쿨 레포에서의 코드와 비교했을 때, 코드 내 달라진 점은 없으나 react-hook-form 버전이 다른 것을 확인해 버전 차이로 발생한 이슈인 것으로 판단했습니다.
  - 기존: 7.47.0, 현 레포: 7.56.4