### PR TITLE
fix: button, border 기존 레포에서 적용되어 있는 default style 적용

### DIFF
--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -68,4 +68,16 @@
   .scrollable::-webkit-scrollbar-button {
     display: none;
   }
+
+  [role='button'],
+  button {
+    cursor: pointer;
+  }
+
+  *,
+  :after,
+  :before {
+    border: 0 solid #e5e7eb;
+    box-sizing: border-box;
+  }
 }

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -77,7 +77,7 @@
   *,
   :after,
   :before {
-    border: 0 solid #e5e7eb;
+    border: 0 solid var(--color-gray-200);
     box-sizing: border-box;
   }
 }


### PR DESCRIPTION
기존 레포에 적용되어 있던 테일윈드 기본 스타일이 신규 레포에서 테일윈드 버전이 달라짐에 따라 제공되지 않아,
기존 레포와 다른 스타일이 적용되어 있는 부분을 수정했습니다.
추가적으로 어느부분이 기존 테일윈드에서 제공하던 기본 스타일이 적용되어 있지 않은지 파악이 안 되어, 추후 지금처럼 작성해야 할 가능성이 있습니다.
그때도 지금처럼 components.css에 작성하면 될 것 같습니다!