### PR TITLE
선생님 학생카드 URL 구조 수정

### DIFF
--- a/src/routers/domain/teacher.router.tsx
+++ b/src/routers/domain/teacher.router.tsx
@@ -175,14 +175,15 @@ export const teacherRoutes = {
       path: 'studentcard',
       element: <StudentCardPage />,
       children: [
+        { path: ':groupId', element: <StudentCardPage /> },
         {
-          path: ':groupId',
+          path: ':groupId/:id',
           element: <StudentCardDetailPage />,
           children: [
-            { path: ':id/all', element: <StudyInfoCard2 isCard={true} /> },
-            { path: ':id/activityv3', element: <ActivityV3CardPage /> },
+            { path: 'all', element: <StudyInfoCard2 isCard={true} /> },
+            { path: 'activityv3', element: <ActivityV3CardPage /> },
             {
-              path: ':id/score',
+              path: 'score',
               element: <ScoreCardPage />,
               children: [
                 { index: true, element: <AllScore /> },
@@ -190,10 +191,10 @@ export const teacherRoutes = {
                 { path: 'analysis', element: <ScoreAnalysis /> },
               ],
             },
-            { path: ':id/counseling', element: <Counselingv3Card /> },
-            { path: ':id/general', element: <GeneralCardPage /> },
-            { path: ':id/default', element: <AllCardPage /> },
-            { path: ':id/pointlogs', element: <PointLogsPage /> },
+            { path: 'counseling', element: <Counselingv3Card /> },
+            { path: 'general', element: <GeneralCardPage /> },
+            { path: 'default', element: <AllCardPage /> },
+            { path: 'pointlogs', element: <PointLogsPage /> },
           ],
         },
       ],


### PR DESCRIPTION
`/teacher/studentcard/:groupId` 경로에서 바로 `StudentDetailCardPage` 가 출력되는 이슈 **라우터 구조 수정**
<img width="2032" alt="스크린샷 2025-05-26 오후 9 09 07" src="https://github.com/user-attachments/assets/c235b701-ae86-4637-893b-34395cbd9ba4" />
<img width="2032" alt="스크린샷 2025-05-26 오후 9 09 17" src="https://github.com/user-attachments/assets/bf799067-935d-40b4-ad0d-89e89b39f6e4" />

